### PR TITLE
WIP fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Only needed the first time:
 sudo apt-get install cargo npm ruby-mustache
 # Required version >= 0.1.1
 cargo install --git https://github.com/Kixunil/debcrafter
+PATH=$PATH:~/.cargo/bin
 cargo install cfg_me
 make build-dep
 ```


### PR DESCRIPTION
the command `cargo install --git https://github.com/Kixunil/debcrafter` returns at the end `warning: be sure to add `/home/user/.cargo/bin` to your PATH to be able to run the installed binaries`.

adding `PATH=$PATH:~/.cargo/bin` to the instructions