### PR TITLE
add git clone & cd & rename to build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Only needed the first time:
 git clone https://github.com/Kixunil/cryptoanarchy-deb-repo-builder
 cd cryptoanarchy-deb-repo-builder
 sudo apt-get install cargo npm ruby-mustache
-# Required version >= 0.1.1
+# Required debcrafter version >= 0.1.1
 cargo install --git https://github.com/Kixunil/debcrafter
 PATH=$PATH:~/.cargo/bin
 cargo install cfg_me

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cargo install --git https://github.com/Kixunil/debcrafter
 PATH=$PATH:~/.cargo/bin
 cargo install cfg_me
 make BUILD_DIR=$PWD/build build-dep
-make
+make BUILD_DIR=$PWD/build
 ```
 
 Supported and planned applications

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Only needed the first time:
 git clone https://github.com/Kixunil/cryptoanarchy-deb-repo-builder
 cd cryptoanarchy-deb-repo-builder
 sudo apt-get install cargo npm ruby-mustache
-# Required debcrafter version >= 0.1.1
+# Requires the latest debcrafter version
 cargo install --git https://github.com/Kixunil/debcrafter
 PATH=$PATH:~/.cargo/bin
 cargo install cfg_me

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ The only officially supported OS for building and running is currently **Debian 
 It may work on recent version of Ubuntu and derived systems, but it's not tested. Contributions
 (trying it and reportin) welcome!
 This part is relevant only if you want to develop the repository or build it on your own.
-Only needed the first time:
+
+Only needed for the first time:
 
 ```
 git clone https://github.com/Kixunil/cryptoanarchy-deb-repo-builder
@@ -109,6 +110,10 @@ cargo install --git https://github.com/Kixunil/debcrafter
 PATH=$PATH:~/.cargo/bin
 cargo install cfg_me
 make BUILD_DIR=$PWD/build build-dep
+```
+
+For all subsequent builds:
+```
 make BUILD_DIR=$PWD/build
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ sudo apt-get install cargo npm ruby-mustache
 cargo install --git https://github.com/Kixunil/debcrafter
 PATH=$PATH:~/.cargo/bin
 cargo install cfg_me
-make build-dep
+make BUILD_DIR=$PWD/build build-dep
 make
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ About this **GitHub** repository
 This **GitHub** repository contains a set of makefiles and other tools to build the **Debian** repository.
 It's useless to you unless you are trying to build it on your own or help with development.
 
-Build Dependencies
+Build Instructions
 ------------------
 
 The only officially supported OS for building and running is currently **Debian 10 (Buster)**!
@@ -101,18 +101,16 @@ This part is relevant only if you want to develop the repository or build it on 
 Only needed the first time:
 
 ```
+git clone https://github.com/Kixunil/cryptoanarchy-deb-repo-builder
+cd cryptoanarchy-deb-repo-builder
 sudo apt-get install cargo npm ruby-mustache
 # Required version >= 0.1.1
 cargo install --git https://github.com/Kixunil/debcrafter
 PATH=$PATH:~/.cargo/bin
 cargo install cfg_me
 make build-dep
+make
 ```
-
-Building
---------
-
-`make`
 
 Supported and planned applications
 ----------------------------------


### PR DESCRIPTION
should be obvious, but it's good to make it explicit.