### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys BC528686B50D79E339D3721CE
 gpg --export 3D9E81D3CA76CDCBE768C4B4DC6B4F8E60B8CF4C | sudo apt-key add -
 gpg --export BC528686B50D79E339D3721CEB3E94ADBE1229CF | sudo apt-key add -
 echo 'deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/debian/10/prod buster main' | sudo tee /etc/apt/sources.list.d/microsoft.list > /dev/null
-echo 'deb https://deb.ln-ask.me/beta buster common local desktop' | sudo tee /etc/apt/sources.list.d/cryptoanarchy.list > /dev/null
+echo 'deb [signed-by=3D9E81D3CA76CDCBE768C4B4DC6B4F8E60B8CF4C] https://deb.ln-ask.me/beta buster common local desktop' | sudo tee /etc/apt/sources.list.d/cryptoanarchy.list > /dev/null
 sudo apt update
 ```
 


### PR DESCRIPTION
signed-by= should be used in repository definition. Without signed-by, packages will be validated against all the available keys from the keyring and not only the one of the owner of the repository.