### PR TITLE
Fix build directory issue in update_packages.py by using absolute path

### DIFF
--- a/tools/update_packages.py
+++ b/tools/update_packages.py
@@ -209,9 +209,12 @@ def run_update_pin(package_name, source_name):
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     
     try:
-        # Run make update-pin
+        # Set BUILD_DIR to an absolute path (equivalent to $HOME/cadr-build)
+        build_dir = os.path.expanduser("~/cadr-build")
+        
+        # Run make update-pin with BUILD_DIR set to absolute path
         run_command(
-            ["make", f"SOURCES={source_name}", "update-pin"],
+            ["make", f"SOURCES={source_name}", f"BUILD_DIR={build_dir}", "update-pin"],
             cwd=repo_root,
             capture_output=False
         )


### PR DESCRIPTION
There's something broken with the current build system as it doesn't work with relative path. I have no interest now to chase that bug so just workaround it by passing an absolute path.